### PR TITLE
recovery: Add new rules for recursive wipe

### DIFF
--- a/sepolicy/recovery.te
+++ b/sepolicy/recovery.te
@@ -30,6 +30,10 @@ allow recovery sdcard_posix:file r_file_perms;
 allow recovery recovery_prop:property_service set;
 
 # recursive rm for wipes... :(
+allow app_data_file self:filesystem associate;
+allow recovery app_data_file:file { read open create write };
+allow recovery app_data_file:filesystem { relabelto relabelfrom mount unmount };
+
 allow recovery file_type:dir { rw_dir_perms rmdir };
 allow recovery file_type:notdevfile_class_set { unlink getattr };
 # wipe saves and restores the layout version


### PR DESCRIPTION
We now use a temporary context when mounting /data, so add permissions
to do that, and add permissions necessary to do the recursive wipe.

Change-Id: Ic925c70f1cf01c8b19a6ac48a9468d6eb9205321